### PR TITLE
State namespacing based on name

### DIFF
--- a/ruby/lib/environment.rb
+++ b/ruby/lib/environment.rb
@@ -75,13 +75,13 @@ class Environment
     end
 
     def args
-      args = @data.lookup("#{self.tf_module.gsub('/','::')}::args")
+      args = @data.lookup("#{@name}::args")
       return args if args != nil
       return ""
     end
 
     def has_vars?
-      vars = @data.lookup("#{self.tf_module.gsub('/','::')}::vars")
+      vars = @data.lookup("#{@name}::vars")
       return true if vars.is_a?(Hash) && !vars.empty?
       return false
     end
@@ -89,7 +89,7 @@ class Environment
     def inputs
       inputs = Array.new
       if self.has_vars?
-        @data.hash_lookup("#{self.tf_module.gsub('/','::')}::vars").each do |k,v|
+        @data.hash_lookup("#{@name}::vars").each do |k,v|
           inputs.push(Input.new(k,v))
         end
       end
@@ -97,7 +97,7 @@ class Environment
     end
 
     def has_targets?
-      targets = @data.lookup("#{self.tf_module.gsub('/','::')}::targets")
+      targets = @data.lookup("#{@name}::targets")
       return true if targets.is_a?(Hash) && !targets.empty?
       return false
     end
@@ -105,7 +105,7 @@ class Environment
     def contexts
       contexts = Array.new
       if self.has_targets?
-        @data.hash_lookup("#{self.tf_module.gsub('/','::')}::targets").each do |k,v|
+        @data.hash_lookup("#{@name}::targets").each do |k,v|
           contexts.push(Context.new(k,v))
         end
       else

--- a/ruby/lib/tools/terraform.rb
+++ b/ruby/lib/tools/terraform.rb
@@ -101,5 +101,5 @@ module Terraform
   def self.has_state_store?
     return false
   end
-  
+
 end

--- a/spec/data/stacks/rspec-artifact_test.yaml
+++ b/spec/data/stacks/rspec-artifact_test.yaml
@@ -8,7 +8,7 @@ artifact_test::state:
       name: 'example/myapp'
 
 # Input variables
-myapp2::vars:
+artifact_test::vars:
   label: 'test'
   ami:
     type: 'atlas.artifact'
@@ -17,6 +17,7 @@ myapp2::vars:
     key: 'region.us-west-2'
 
 # Test data
+# XXX: maybe split this out to a different test file
 myapp2::array_test:
   - 'stack_data'
 myapp2::array_test_1:


### PR DESCRIPTION
`??::state` namespace to be based on module name instead of module path
to allow multiple instances of a module to be utilized in a particular
environment build

@blakeneyops semi-blindly applying the lookup change, based on the results from the tests. I don't have a great feel for the library just yet but breaking things seem like a good way to do it 😸 
