### PR TITLE
Remote config fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 BACKWARDS INCOMPATIBILITIES:
 FEATURES:
+- Terraform vars are now fed in via `-var-file` instead of individual `-var` commands. Should be able to leverage the new terraform data types to avoid intermediate serialization of array/hash data.
+
 IMPROVEMENTS:
 FIXES:
+
+## 0.4.2 (September 26, 2016)
+FIXES:
+- Terraform remote config now works from the module path instead of a temporary directory, which should ensure that the state gets read correctly when ran from a docker context
 
 ## 0.4.1 (September 25, 2016)
 

--- a/lib/covalence/core/services/terraform_stack_tasks.rb
+++ b/lib/covalence/core/services/terraform_stack_tasks.rb
@@ -55,11 +55,11 @@ module Covalence
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) do
           logger.info "In #{tmpdir}:"
-          TerraformCli.terraform_remote_config(args: store_args)
+          TerraformCli.terraform_remote_config(path, args: store_args)
 
           stack.state_stores.drop(1).each do |store|
-            TerraformCli.terraform_remote_config(args: '-disable')
-            TerraformCli.terraform_remote_config(args: "#{store.get_config} -pull=false")
+            TerraformCli.terraform_remote_config(path, args: '-disable')
+            TerraformCli.terraform_remote_config(path, args: "#{store.get_config} -pull=false")
             TerraformCli.terraform_remote_push(path)
           end
         end
@@ -75,8 +75,8 @@ module Covalence
           logger.info "In #{tmpdir}:"
           TerraformCli.terraform_get(path)
 
-          TerraformCli.terraform_remote_config(args: store_args.split(" "))
-          TerraformCli.terraform_remote_config(args: ["-disable"])
+          TerraformCli.terraform_remote_config(path, args: store_args.split(" "))
+          TerraformCli.terraform_remote_config(path, args: ["-disable"])
           args = collect_args(stack.materialize_cmd_inputs,
                               "-input=false",
                               "-module-depth=-1",
@@ -97,8 +97,8 @@ module Covalence
           logger.info "In #{tmpdir}:"
           TerraformCli.terraform_get(path)
 
-          TerraformCli.terraform_remote_config(args: store_args.split(" "))
-          TerraformCli.terraform_remote_config(args: ["-disable"])
+          TerraformCli.terraform_remote_config(path, args: store_args.split(" "))
+          TerraformCli.terraform_remote_config(path, args: ["-disable"])
           args = collect_args(stack.materialize_cmd_inputs,
                               "-destroy",
                               "-input=false",
@@ -120,7 +120,7 @@ module Covalence
           logger.info "In #{tmpdir}:"
 
           TerraformCli.terraform_get(path)
-          TerraformCli.terraform_remote_config(args: store_args)
+          TerraformCli.terraform_remote_config(path, args: store_args)
           apply_args = collect_args(stack.materialize_cmd_inputs,
                                     stack.args,
                                     additional_args)
@@ -143,7 +143,7 @@ module Covalence
           logger.info "In #{tmpdir}:"
 
           TerraformCli.terraform_get(path)
-          TerraformCli.terraform_remote_config(args: store_args)
+          TerraformCli.terraform_remote_config(path, args: store_args)
           destroy_args = collect_args(stack.materialize_cmd_inputs,
                                       stack.args,
                                       additional_args)

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/spec/rake/environment_tasks_spec.rb
+++ b/spec/rake/environment_tasks_spec.rb
@@ -337,9 +337,9 @@ module Covalence
       end
 
       it "should sync state from the primary remote state" do
-        expect(TerraformCli).to receive(:terraform_remote_config).with(args: /-backend=Atlas/)
-        expect(TerraformCli).to receive(:terraform_remote_config).with(args: '-disable')
-        expect(TerraformCli).to receive(:terraform_remote_config).with(args: /-backend=s3/)
+        expect(TerraformCli).to receive(:terraform_remote_config).with(anything, args: /-backend=Atlas/)
+        expect(TerraformCli).to receive(:terraform_remote_config).with(anything, args: '-disable')
+        expect(TerraformCli).to receive(:terraform_remote_config).with(anything, args: /-backend=s3/)
         expect(TerraformCli).to receive(:terraform_remote_push)
         subject.invoke
       end


### PR DESCRIPTION
- Terraform remote config now works from the module path instead of a
  temporary directory, which should ensure that the state gets read
  correctly when ran from a docker context
