### PR TITLE
Fix missing CI tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,14 +21,14 @@ namespace :spec do
   # TODO: Might be able to just use the default rspec spec?
   desc 'Run Covalence tests'
   RSpec::Core::RakeTask.new(:covalence) do |t|
-    t.pattern = "#{File.join(Covalence::PROJECT_ROOT, 'spec/**/*_spec.rb')}"
+    t.pattern = "#{File.join(File.dirname(__FILE__), 'spec/**/*_spec.rb')}"
     t.rspec_opts = "--color --format documentation"
     t.verbose = true
   end
 
   desc 'Run CircleCI friendly Covalence tests'
   RSpec::Core::RakeTask.new(:circleci) do |t|
-    t.pattern = "#{File.join(Covalence::PROJECT_ROOT, 'spec/**/*_spec.rb')}"
+    t.pattern = "#{File.join(File.dirname(__FILE__), 'spec/**/*_spec.rb')}"
     t.rspec_opts = "--color --format documentation --tag ~native"
     t.verbose = true
   end

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   environment:
-    COVALENCE_VERSION: 0.1.3
+    COVALENCE_VERSION: 0.4.4
     ATLAS_TOKEN: GryCCpG3GRBqQw.atlasv1.1ASD0jMKyVmLmUVlqP7ca6xdxqzY1nNroAVtTSKRBYR7fnLxciPCboidfwKR6bXBaWQ
     TERRAFORM_IMG: unifio/terraform:latest
     TERRAFORM_CMD: "docker run -e ATLAS_TOKEN=$ATLAS_TOKEN --rm"

--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -25,7 +25,6 @@ module Covalence
   TERRAFORM_VERSION = ENV['TERRAFORM_VERSION'] || `#{TF_CMD} #{TF_IMG} version`.split("\n", 2)[0].gsub('Terraform v','')
 
   # Internal constants
-  PROJECT_ROOT = File.expand_path('../../../', __FILE__).freeze
   GEM_ROOT = File.expand_path('covalence', File.dirname(__FILE__)).freeze
   # look into logger-colors
   LOGGER = Logger.new(STDOUT)

--- a/spec/core/entities/input_spec.rb
+++ b/spec/core/entities/input_spec.rb
@@ -36,11 +36,20 @@ module Covalence
       end
 
       context "new terraform api remote API response format" do
+        let(:tf_version) { "0.7.4" }
         let(:remote_value) do
           {
             "sensitive": false,
             "type": "string",
             "value": "foo"
+          }
+        end
+
+        before(:each) do
+          ENV['TERRAFORM_VERSION'] = tf_version
+          # force constants to re-init
+          Kernel.silence_warnings {
+            load File.join(Covalence::GEM_ROOT, '../covalence.rb')
           }
         end
 


### PR DESCRIPTION
- Removing `PROJECT_ROOT`, usage context can probably be derived from
  Rakefile location
- Harden remote input test (was on a machine that had terraform 0.6.x
  native)
- Fix environment and system specific dependent issues with
  terraform_cli_spec tests
