### PR TITLE
0.5.2 (October 12, 2016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ IMPROVEMENTS:
 
 FIXES:
 
+## 0.5.2 (October 12, 2016)
+FEATURES:
+- Packer can now be ran from docker containers. Follows the same conventions as terraform by specifying `PACKER_IMG`, `PACKER_CMD`
+
+FIXES:
+- More minor PopenWrapper return code fixes
+- Allow packer to deal with shell interpolation values via the same terraform shell interpolation prefix: `$(...`
+
+
 ## 0.5.1 (October 10, 2016)
 
 FEATURES:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    covalence (0.5.1)
+    covalence (0.5.2)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       aws-sdk (~> 2.3.8)
@@ -123,7 +123,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (4.4.1)
-    specinfra (2.63.1)
+    specinfra (2.63.3)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -157,7 +157,7 @@ DEPENDENCIES
   dotenv (~> 2.1.0)
   fabrication (~> 2.15.2)
   gemfury (~> 0.6.0)
-  rspec (~> 3.4.0)
+  rspec (~> 3.4)
   serverspec (~> 2.36.0)
   simplecov (~> 0.12.0)
   webmock (~> 2.0.3)

--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -16,13 +16,15 @@ module Covalence
   # TODO: could use better naming
   PACKER = File.absolute_path(File.join(WORKSPACE, (ENV['COVALENCE_PACKER_DIR'] || ENV['PROMETHEUS_PACKER_DIR'] || 'packer')))
   TERRAFORM =  File.absolute_path(File.join(WORKSPACE, (ENV['COVALENCE_TERRAFORM_DIR'] || ENV['PROMETHEUS_TERRAFORM_DIR'] || 'terraform')))
-  PACKER_CMD = ENV['PACKER_CMD'] || "packer"
   TEST_ENVS = (ENV['COVALENCE_TEST_ENVS'] || ENV['PROMETHEUS_TEST_ENVS'] || "").split(',')
 
   # should be able to deprecate this with covalence bundled inside the container
   TERRAFORM_IMG = ENV['TERRAFORM_IMG'] || ""
   TERRAFORM_CMD = ENV['TERRAFORM_CMD'] || "terraform"
   TERRAFORM_VERSION = ENV['TERRAFORM_VERSION'] || `#{TERRAFORM_CMD} #{TERRAFORM_IMG} version`.split("\n", 2)[0].gsub('Terraform v','')
+
+  PACKER_IMG = ENV['PACKER_IMG'] || ""
+  PACKER_CMD = ENV['PACKER_CMD'] || "packer"
 
   # No-op shell command. Should not need to modify for most unix shells.
   DRY_RUN_CMD = (ENV['COVALENCE_DRY_RUN_CMD'] || ":")

--- a/lib/covalence/core/cli_wrappers/packer.yml
+++ b/lib/covalence/core/cli_wrappers/packer.yml
@@ -1,8 +1,8 @@
 ---
-version: Packer v0.10.1
+version: Packer v0.10.2
 commands:
   build:
-  #fix: need to implement once we support CLI run-time args
+  fix:
   inspect:
   push:
   validate:

--- a/lib/covalence/core/cli_wrappers/packer_cli.rb
+++ b/lib/covalence/core/cli_wrappers/packer_cli.rb
@@ -15,12 +15,35 @@ module Covalence
 
           next if respond_to?(packer_cmd.to_sym)
           define_singleton_method(packer_cmd) do |template, args: ''|
-            PopenWrapper.run([Covalence::PACKER_CMD, cmd], template, args)#, dry_run: true)
-          end
-        end
+            if Covalence::PACKER_IMG.blank?
+              output = PopenWrapper.run([Covalence::PACKER_CMD, cmd], template, args)
+              (output == 0)
+            else
+              parent, base = docker_scope_path(template)
+              output = PopenWrapper.run([
+                Covalence::PACKER_CMD,
+                "-v #{parent}:/data -w /data #{Covalence::PACKER_IMG}",
+                cmd],
+                File.join('/data', base),
+                args)
+              (output == 0)
+            end
+          end #define_singleton_method
+        end # definition
       end
-    end
-  end
+
+      # When packer runs inside a container, dir scoping and volume mounts need to be considered.
+      # This enforces the standard that packer modules need to be scoped under the WORKSPACE dir module
+      # to avoid volume mount problems.
+      def docker_scope_path(path)
+        if !path.start_with?(Covalence::WORKSPACE)
+          raise "cannot target packer module #{path} outside WORKSPACE base path: #{Covalence::WORKSPACE}"
+        end
+        [Covalence::WORKSPACE, path.sub(Covalence::WORKSPACE, "")]
+      end
+
+    end # class << self
+  end #PackerCli
 end
 
 Covalence::PackerCli.require_init

--- a/lib/covalence/core/cli_wrappers/popen_wrapper.rb
+++ b/lib/covalence/core/cli_wrappers/popen_wrapper.rb
@@ -31,7 +31,7 @@ module Covalence
         end
 
         if debug
-          return unless HighLine.new.agree('Execute? [y/n]')
+          return 0 unless HighLine.new.agree('Execute? [y/n]')
         end
 
         spawn_subprocess(ENV, run_cmd, {

--- a/lib/covalence/helpers/spec_dependencies.rb
+++ b/lib/covalence/helpers/spec_dependencies.rb
@@ -7,7 +7,7 @@ module Covalence
       def self.dependencies
         {
           "ci_reporter_rspec" => "~> 1.0.0",
-          "rspec" => "~> 3.4.0"
+          "rspec" => "~> 3.4"
         }
       end
 

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/core/cli_wrappers/popen_wrapper_spec.rb
+++ b/spec/core/cli_wrappers/popen_wrapper_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+require 'tempfile'
+require_relative File.join(Covalence::GEM_ROOT, 'core/cli_wrappers/popen_wrapper')
+
+module Covalence
+  RSpec.describe PopenWrapper do
+    describe ".run" do
+      before(:all) do
+        @stdin_io_file = Tempfile.new
+        @stdout_io =
+        @stderr_io = Tempfile.new
+      end
+
+      before(:each) do
+        allow(Covalence::LOGGER).to receive(:warn)
+      end
+
+      after(:all) do
+        @stdin_io_file.close
+        @stdin_io_file.unlink
+      end
+
+      let(:stdin_io) do
+        fd = IO.sysopen('/dev/null', 'r+')
+        IO.new(fd)
+      end
+      let(:stdout_io) do
+        fd = IO.sysopen('/dev/null', 'w+')
+        IO.new(fd)
+      end
+      let(:stderr_io) do
+        fd = IO.sysopen('/dev/null', 'w+')
+        IO.new(fd)
+      end
+
+      let(:cmds) { "echo" }
+      let(:args) { "\'args\'" }
+
+      it "traps SIGINT"
+
+      it "exits with the the process error code with a non-successful exit" do
+        begin
+          described_class.run("exit 1", '', '',
+                              stdin_io: stdin_io,
+                              stdout_io: stdout_io,
+                              stderr_io: stderr_io)
+          expect('should not reach here').to eq(true)
+        rescue SystemExit => e
+          expect(e.status).to eq(1)
+        end
+      end
+
+      it "returns 0 when process terminates successfully" do
+        result = described_class.run(cmds, '', args,
+                                     stdin_io: stdin_io,
+                                     stdout_io: stdout_io,
+                                     stderr_io: stderr_io)
+        expect(result).to eq(0)
+      end
+
+      it "sends the command string to the logger" do
+        expect(Covalence::LOGGER).to receive(:warn)
+        result = described_class.run(cmds, '', args,
+                                     stdin_io: stdin_io,
+                                     stdout_io: stdout_io,
+                                     stderr_io: stderr_io)
+
+        expect(result).to eq(0)
+      end
+
+      context "debug: true" do
+        it "prompts before execution and aborts with exit code 0 when declined to continue" do
+          expect_any_instance_of(HighLine).to receive(:agree).and_return(false)
+          expect(described_class).to_not receive(:spawn_subprocess)
+
+          result = described_class.run(cmds, '', args,
+                                     stdin_io: stdin_io,
+                                     stdout_io: stdout_io,
+                                     stderr_io: stderr_io,
+                                     debug: true)
+
+          expect(result).to eq(0)
+        end
+
+        it "prompts before execution and returns with exit code 0 when accepted to continue" do
+          expect_any_instance_of(HighLine).to receive(:agree).and_return(true)
+          expect(described_class).to receive(:spawn_subprocess).and_call_original
+
+          result = described_class.run(cmds, '', args,
+                                     stdin_io: stdin_io,
+                                     stdout_io: stdout_io,
+                                     stderr_io: stderr_io,
+                                     debug: true)
+
+          expect(result).to eq(0)
+        end
+      end
+
+      context "dry_run: true" do
+        it "replaces the run_cmd string with DRY_RUN_CMD" do
+          expect(described_class).to receive(:spawn_subprocess).with(anything,
+                                                                     Covalence::DRY_RUN_CMD,
+                                                                     anything).and_call_original
+          result = described_class.run(cmds, '', args,
+                                       stdin_io: stdin_io,
+                                       stdout_io: stdout_io,
+                                       stderr_io: stderr_io,
+                                       dry_run: true)
+          expect(result).to eq(0)
+        end
+      end
+
+      context "ignore_exitcode: true" do
+        it "should return 0 when ignoring the exitcode" do
+          result = nil
+          expect {
+            result = described_class.run("exit 1", '', '',
+                                stdin_io: stdin_io,
+                                stdout_io: stdout_io,
+                                stderr_io: stderr_io,
+                                ignore_exitcode: true)
+          }.to_not raise_error
+          expect(result).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/core/services/packer_stack_tasks_spec.rb
+++ b/spec/core/services/packer_stack_tasks_spec.rb
@@ -3,25 +3,66 @@ require_relative File.join(Covalence::GEM_ROOT, 'core/services/packer_stack_task
 
 module Covalence
   RSpec.describe PackerStackTasks do
+    let(:environment_name) { "example_environment" }
+    let(:packer_template) { 'packer_template' }
+    let(:args) { '-args' }
+    let(:name) { 'name' }
+    let(:stack) do
+      Fabricate(:packer_stack,
+                name: name,
+                environment_name: environment_name,
+                packer_template: packer_template,
+                args: args,
+                inputs: {
+                  'local_input' => Fabricate(:local_input, type: 'packer'),
+                })
+    end
+
+    before(:each) do
+      allow(PackerCli).to receive(:public_send)
+    end
+
     describe "#stack_name" do
-      pending
+      it "returns the stack name" do
+        expect(described_class.new(stack).stack_name).to eq(name)
+      end
     end
 
     describe "#environment_name" do
-      pending
+      it "returns the environment name" do
+        expect(described_class.new(stack).environment_name).to eq(environment_name)
+      end
     end
 
     describe "#context_build" do
+      it "calls packer build with specific args" do
+        expect(PackerCli).to receive(:public_send).with(
+          :packer_build, anything, { args: array_including(
+            "-var 'local_input=foo'",
+            args
+          )})
+        described_class.new(stack).context_build
+      end
+
       # TODO: check tempfile is generated in packer module directory
-      pending
     end
 
     describe "#context_inspect" do
-      pending
+      it "calls packer inspect with specific args" do
+        expect(PackerCli).to receive(:public_send).with(:packer_inspect, anything, { args: [] })
+        described_class.new(stack).context_inspect
+      end
     end
 
     describe "#context_validate" do
-      pending
+      it "calls packer validate with specific args" do
+        expect(PackerCli).to receive(:public_send).with(
+          :packer_validate, anything, { args: array_including(
+            "-var 'local_input=foo'",
+            args
+          )})
+        described_class.new(stack).context_validate
+      end
     end
   end
 end

--- a/spec/fabricators/stack_fabricator.rb
+++ b/spec/fabricators/stack_fabricator.rb
@@ -3,7 +3,6 @@ require_relative File.join(Covalence::GEM_ROOT, 'core/entities/stack')
 Fabricator(:stack, from: 'Covalence::Stack') do
   on_init { init_with(name: "example_stack") }
   environment_name "example_environment"
-  state_stores { Fabricate.times(3, :state_store) }
   inputs do
     {
       'local_input' => Fabricate(:local_input),
@@ -12,10 +11,10 @@ Fabricator(:stack, from: 'Covalence::Stack') do
   end
   contexts { Fabricate.times(2, :context) }
   args "-no-color"
-  #tf_module
-  #packer_template
-  #state_stores
-  #inputs
+  #state_stores - terraform only
+  #tf_module - terraform only
+  #packer_template - packer only
+  #state_stores - terraform only
 
   after_build(&:valid?)
 end
@@ -23,7 +22,8 @@ end
 Fabricator(:terraform_stack, from: :stack) do
   on_init do
     init_with(name: "example_stack",
-              type: "terraform")
+              type: "terraform",
+              state_stores: Fabricate.times(3, :state_store))
   end
 end
 
@@ -31,6 +31,7 @@ end
 Fabricator(:packer_stack, from: :stack) do
   on_init do
     init_with(name: "example_stack",
-              type: "packer")
+              type: "packer",
+              packer_template: 'example_packer_template')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,9 @@ require 'webmock/rspec'
 require 'simplecov'
 
 Dotenv.load(*%w(.env .env.test))
-SimpleCov.start
+SimpleCov.start do
+  add_filter 'spec/'
+end
 require_relative '../lib/covalence'
 
 Fabrication.manager.load_definitions


### PR DESCRIPTION
FEATURES:
- Packer can now be ran from docker containers. Follows the same
  conventions as terraform by specifying `PACKER_IMG`, `PACKER_CMD`

FIXES:
- More minor PopenWrapper return code fixes
- Allow packer to deal with shell interpolation values via the same
  terraform shell interpolation prefix: `$(...`
