### PR TITLE
0.5.3 (October 19, 2016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ IMPROVEMENTS:
 
 FIXES:
 
+## 0.5.3 (October 19, 2016)
+FIXES:
+- terraform destroy tasks receive the `-force` param instead of `-input=false`.
+- `env:spec` only does format checking on the specific path module, not the dependent modules referenced underneath.
+
 ## 0.5.2 (October 12, 2016)
 FEATURES:
 - Packer can now be ran from docker containers. Follows the same conventions as terraform by specifying `PACKER_IMG`, `PACKER_CMD`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    covalence (0.5.2)
+    covalence (0.5.3)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       aws-sdk (~> 2.3.8)

--- a/lib/covalence/rake/rspec/envs_spec.rb
+++ b/lib/covalence/rake/rspec/envs_spec.rb
@@ -13,7 +13,6 @@ module Covalence
 
         before(:all) do
           TerraformCli.terraform_clean(path)
-          TerraformCli.terraform_get(path)
         end
 
         it 'passes style check' do
@@ -27,6 +26,8 @@ module Covalence
         end
 
         it 'passes execution' do
+          TerraformCli.terraform_get(path)
+
           args = stack.materialize_cmd_inputs + [
             "-input=false",
             "-module-depth=-1",

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/spec/rake/environment_tasks_spec.rb
+++ b/spec/rake/environment_tasks_spec.rb
@@ -236,7 +236,8 @@ module Covalence
         expect(TerraformCli).to receive(:terraform_destroy).with(anything, hash_including(args: [
           "-var 'label=\"test\"'",
           "-no-color",
-          "-target=\"module.az0\""
+          "-target=\"module.az0\"",
+          "-force",
         ]))
         subject.invoke
       end
@@ -318,12 +319,13 @@ module Covalence
       end
 
       it "executes a destroy" do
-        expect(TerraformCli).to receive(:terraform_destroy).with(anything, hash_including(args: [
+        expect(TerraformCli).to receive(:terraform_destroy).with(anything, hash_including(args: array_including(
           "-var 'label=\"test\"'",
           "-no-color",
           "-target=\"module.az1\"",
-          "-target=\"module.common.aws_eip.myapp\""
-        ]))
+          "-target=\"module.common.aws_eip.myapp\"",
+          "-force",
+        )))
         subject.invoke
       end
     end
@@ -400,7 +402,9 @@ module Covalence
       end
 
       it "executes a destroy" do
-        expect(TerraformCli).to receive(:terraform_destroy).with(anything, hash_including(args: []))
+        expect(TerraformCli).to receive(:terraform_destroy).with(anything, hash_including(args: array_including(
+          "-force",
+        )))
         subject.invoke
       end
     end


### PR DESCRIPTION
FIXES:
- terraform destroy tasks receive the `-force` param instead of
  `-input=false`.
- `env:spec` only does format checking on the specific path module, not
  the dependent modules referenced underneath.
