### PR TITLE
Add Terraform get to the sync command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 * Add support for Terraform environments
 * Add ability to toggle primary state store
 
+## 0.7.5 (October 12, 2017)
+IMPROVEMENTS:
+- Fix the sync command to call Terraform get prior to init command.  This is required with new version of Terraform.
+
 ## 0.7.4 (September 26, 2017)
 IMPROVEMENTS:
 - Updated Covalence to work with Terraform 0.10.x.  Updates were made in 0.10.x that requires all variables set for validate to run.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    covalence (0.7.4)
+    covalence (0.7.5)
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       aws-sdk (~> 2.9.5)

--- a/lib/covalence/core/services/terraform_stack_tasks.rb
+++ b/lib/covalence/core/services/terraform_stack_tasks.rb
@@ -71,6 +71,7 @@ module Covalence
           logger.info "In #{tmpdir}:"
 
           stack.materialize_state_inputs
+          TerraformCli.terraform_get(@path)
           TerraformCli.terraform_init
 
           stack.state_stores.drop(1).each do |store|

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.7.4"
+  VERSION = "0.7.5"
 end


### PR DESCRIPTION
With latest version of Terraform, sync command no longer works.  The get command needs to be run before the init.  We are doing this for other commands, just not sync.