### PR TITLE
Update homedir for non root user

### DIFF
--- a/example/bin/.covalence/launcher
+++ b/example/bin/.covalence/launcher
@@ -260,7 +260,7 @@ if [[ "${DOCKER_DNS}" ]]; then
 fi
 
 if [[ "${CONTAINER_USER_ID}" ]]; then
-  DOCKER_HOMEDIR=""
+  DOCKER_HOMEDIR="/home/user"
   add_arg_simple "-e" "AWS_CONFIG_FILE=${DOCKER_HOMEDIR}/.aws/config"
   add_arg_simple "-e" "AWS_SHARED_CREDENTIALS_FILE=${DOCKER_HOMEDIR}/.aws/credentials"
   add_arg_simple "-e" "USER=user"


### PR DESCRIPTION
This doesn't work with the container entrypoint script.  That sets the HOME=/home/user.  Ruby expects to find the aws credentials in ~/.aws.  Otherwise, we get the following error:

`Aws::Errors::MissingCredentialsError: unable to sign request without credentials set`