### PR TITLE
Fixing GET_PLUGINS default to be string not bool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - image: circleci/ruby:2.5.5
 
     environment:
-      COVALENCE_VERSION: 0.9.3
+      COVALENCE_VERSION: 0.9.4
       TERRAFORM_VERSION: 0.12.6
       SOPS_VERSION: 3.3.1
       BUNDLER_VERSION: 1.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.3 (Aug 30, 2019)
+## 0.9.4 (Aug 30, 2019)
 
 FIXES:
 - Issue [#82](https://github.com/unifio/covalence/issues/82) Introduced in v0.9.2 that prevented terraform cli from being cappable of downloading updated plugins/providers.

--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -24,7 +24,7 @@ module Covalence
   TERRAFORM_CMD = ENV['TERRAFORM_CMD'] || "terraform"
   TERRAFORM_VERSION = ENV['TERRAFORM_VERSION'] || `#{TERRAFORM_CMD} version`.split("\n", 2)[0].gsub('Terraform v','')
   TERRAFORM_PLUGIN_CACHE = File.absolute_path("#{ENV['TF_PLUGIN_CACHE_DIR']}/linux_amd64" || "#{ENV['HOME']}/.terraform.d/plugin-cache/linus_amd64")
-  TERRAFORM_GET_PLUGINS =  (ENV['COVALENCE_TERRAFORM_GET_PLUGINS'] || true) =~ (/(true|t|yes|y|1)$/i)
+  TERRAFORM_GET_PLUGINS =  (ENV['COVALENCE_TERRAFORM_GET_PLUGINS'] || "true") =~ (/(true|t|yes|y|1)$/i)
 
   PACKER_CMD = ENV['PACKER_CMD'] || "packer"
 

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end


### PR DESCRIPTION
* Was setting to a string instead of a bool if COVALENCE_TERRAFORM_GET_PLUGINS wasn't set which would always fail comparison to string.
* Replaced 0.9.3 with 0.9.4. This is required to avoid error pushing new gem.