### PR TITLE
Fix destination typo for stack exports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - image: circleci/ruby:2.5.5
 
     environment:
-      COVALENCE_VERSION: 0.9.5
+      COVALENCE_VERSION: 0.9.6
       TERRAFORM_VERSION: 0.12.6
       SOPS_VERSION: 3.3.1
       BUNDLER_VERSION: 1.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.5 (Sep 9, 2019)
+## 0.9.6 (Sep 9, 2019)
 
 IMPROVEMENTS:
 - Issue [#86](https://github.com/unifio/covalence/issues/86) Add ability to export stacks to a stack_exports directory.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    covalence (0.9.5)
+    covalence (0.9.6)
       activemodel (~> 5.2.0)
       activesupport (~> 5.2.0)
       aws-sdk-s3 (~> 1)

--- a/lib/covalence/environment_tasks.rb
+++ b/lib/covalence/environment_tasks.rb
@@ -127,7 +127,7 @@ module Covalence
         packer_tasks.context_validate(target_args, custom_opts.args)
       end
 
-      desc "Export the #{stack_name} stack of the #{environment_name} environment to packer/#{Covalence::STACK_EXPORT}"
+      desc "Export the #{stack_name} stack of the #{environment_name} environment to #{Covalence::STACK_EXPORT}/packer"
       task generate_rake_taskname(environment_name, stack_name, "packer_stack_export") do
         packer_tasks.packer_stack_export()
       end
@@ -171,7 +171,7 @@ module Covalence
         tf_tasks.stack_shell
       end
 
-      desc "Export the #{stack_name} stack of the #{environment_name} environment to terraform/#{Covalence::STACK_EXPORT}"
+      desc "Export the #{stack_name} stack of the #{environment_name} environment to #{Covalence::STACK_EXPORT}/terraform"
       task generate_rake_taskname(environment_name, stack_name, "stack_export") do
         tf_tasks.stack_export
       end

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.9.5"
+  VERSION = "0.9.6"
 end


### PR DESCRIPTION
* Updated the description of tasks with stack exports to have the correct location.
* Increased version number since gem push will fail attempting to overwrite prior release.