### PR TITLE
Add input processing to packer stacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - image: circleci/ruby:2.5.5
 
     environment:
-      COVALENCE_VERSION: 0.9.6
+      COVALENCE_VERSION: 0.9.7
       TERRAFORM_VERSION: 0.12.6
       SOPS_VERSION: 3.3.1
       BUNDLER_VERSION: 1.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.7 (Sep 14, 2019)
+
+IMPROVEMENTS:
+- Issue [#88](https://github.com/unifio/covalence/issues/88) Add input processing to packer stacks. Allows for shell interpolation processing on inputs for packer stacks.
+- Can use the shell interpolation in the template to generate AWS assume role temporary keys to populate template. This allows for role assumption since role assumption is not supported from `~/.aws/config` attributes.
+
 ## 0.9.6 (Sep 9, 2019)
 
 IMPROVEMENTS:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    covalence (0.9.6)
+    covalence (0.9.7)
       activemodel (~> 5.2.0)
       activesupport (~> 5.2.0)
       aws-sdk-s3 (~> 1)

--- a/lib/covalence/core/entities/input.rb
+++ b/lib/covalence/core/entities/input.rb
@@ -28,6 +28,10 @@ module Covalence
       "#{name} = #{parse_input(value())}"
     end
 
+    def to_command_hash_elements
+       return name, parse_input(value()).delete_prefix('"').delete_suffix('"')
+    end
+
     private
 
     def get_value(input)

--- a/lib/covalence/core/entities/stack.rb
+++ b/lib/covalence/core/entities/stack.rb
@@ -51,8 +51,8 @@ module Covalence
         File.open("#{path}/covalence-inputs.tfvars",'w') {|f| f.write(config)}
       elsif type == "packer"
         config = Hash.new
-        inputs.each do |name, input|
-          config[name] = input.value
+        inputs.values.map(&:to_command_hash_elements).each do |name, input|
+          config["#{name}"] = input
         end
         config_json = JSON.generate(config)
         logger.info "path: #{path} module_path: #{module_path}\nStack inputs:\n\n#{config_json}"

--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = "0.9.6"
+  VERSION = "0.9.7"
 end


### PR DESCRIPTION
Issue #88

* Added to_command_hash_elements to allow processing packers inputs.
* Now interpolation of shell commands will function as expected in packer.
* Leveraged mainly for generating aws keys in template to allow seamless role assumption for provisioners and builders.
